### PR TITLE
feat: added resolver for main repo as local dependency

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -28,7 +28,7 @@ module.exports = {
   resolver: {
     extraNodeModules: new Proxy(extraNodeModules, {
       get: (target, name) =>
-        //redirects dependencies referenced from common/ to local node_modules
+        //redirects dependencies referenced from ../swiftui-react-native to local node_modules
         name in target
           ? target[name]
           : path.join(process.cwd(), `node_modules/${name}`),

--- a/metro.config.js
+++ b/metro.config.js
@@ -2,8 +2,19 @@
  * Metro configuration for React Native
  * https://github.com/facebook/react-native
  *
+ * Importing the swiftui-react-native project
+ * https://dushyant37.medium.com/how-to-import-files-from-outside-of-root-directory-with-react-native-metro-bundler-18207a348427
+ *
  * @format
  */
+
+const path = require('path');
+const extraNodeModules = {
+  common: path.resolve(__dirname + '/../swiftui-react-native/dist'),
+};
+const watchFolders = [
+  path.resolve(__dirname + '/../swiftui-react-native/dist'),
+];
 
 module.exports = {
   transformer: {
@@ -14,4 +25,14 @@ module.exports = {
       },
     }),
   },
+  resolver: {
+    extraNodeModules: new Proxy(extraNodeModules, {
+      get: (target, name) =>
+        //redirects dependencies referenced from common/ to local node_modules
+        name in target
+          ? target[name]
+          : path.join(process.cwd(), `node_modules/${name}`),
+    }),
+  },
+  watchFolders,
 };

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "react-native": "0.66.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.3.0-beta.2",
-    "react-native-sfsymbols": "1.1.0",
-    "swiftui-react-native": "file:../swiftui-react-native/dist"
+    "react-native-sfsymbols": "1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
How it works:

- rollup watch will keep `dist` up-to-date
- metro watch will track changes in `dist` and hot-reload on them

See https://dushyant37.medium.com/how-to-import-files-from-outside-of-root-directory-with-react-native-metro-bundler-18207a348427

Works great imo!